### PR TITLE
page.open() doesn't work for local files

### DIFF
--- a/bin/converter.js
+++ b/bin/converter.js
@@ -32,6 +32,7 @@
 
 var page = require('webpage').create();
 var args = require('system').args;
+var fs = require('fs');
 
 function errorHandler(e) {
     console.log(JSON.stringify({
@@ -58,7 +59,7 @@ try {
         'User-Agent': 'PhantomJS'
     };
 
-    page.open(uri, function (status) {
+    page.onLoadFinished = function(status) {
         try {
             if (status !== 'success') {
                 throw 'Unable to access the URI!';
@@ -78,7 +79,16 @@ try {
         } catch (e) {
             errorHandler(e);
         }
-    });
+    };
+
+    if (uri.substr(0,7) == 'file://') {
+        var f = fs.open(uri.substr(7), 'r');
+        page.content = f.read();
+        f.close();
+    } else {
+        page.open(uri);
+    }
+
 } catch (e) {
     errorHandler(e);
 }

--- a/src/H2P/Converter.php
+++ b/src/H2P/Converter.php
@@ -157,7 +157,7 @@ class Converter
     {
         $uri = $this->uri;
         if ($this->uri instanceof TempFile) {
-            $uri = $this->uri->getFileName();
+            $uri = $this->uri->getFileURI();
         }
 
         $destination = $this->destination;

--- a/src/H2P/TempFile.php
+++ b/src/H2P/TempFile.php
@@ -78,6 +78,16 @@ class TempFile
     }
 
     /**
+     * Get the file URI
+     *
+     * @
+     */
+    public function getFileURI()
+    {
+        return 'file://' . $this->getFileName();
+    }
+
+    /**
      * Get the file content
      *
      * @return string


### PR DESCRIPTION
I was not able to use Tempfiles as input: page.open() failed on opening local files. Using a file:// prefix didn't fix this. So I wrote this patch that used the filesystem module to open the file if it has a file:// prefix.
