### PR TITLE
Fix for the JSON decode error.

### DIFF
--- a/bin/converter.js
+++ b/bin/converter.js
@@ -48,8 +48,9 @@ try {
         throw 'You must pass the URI and the Destination param!';
     }
 
-    // Take all options in one JSON param
-    var options = JSON.parse(args[1]);
+    // Decode the provided base64 encoded string then parse it as JSON to use as our parameters.
+	var decoded_base64 = atob(args[1]),
+		options = JSON.parse(decoded_base64);
 
     page.customHeaders = options.request.headers;
     phantom.cookies = options.request.cookies;

--- a/src/H2P/Converter/ConverterAbstract.php
+++ b/src/H2P/Converter/ConverterAbstract.php
@@ -116,7 +116,7 @@ abstract class ConverterAbstract
     {
         if (!$origin instanceof Request) {
             if ($origin instanceof TempFile) {
-                $origin = 'file://' . $origin->getFileName();
+                $origin = 'file:///' . $origin->getFileName();
             }
 
             // Create a simple GET request URI

--- a/src/H2P/Converter/PhantomJS.php
+++ b/src/H2P/Converter/PhantomJS.php
@@ -277,7 +277,7 @@ class PhantomJS extends ConverterAbstract
             'request' => $request,
         ) + $this->options;
 
-        $result = json_decode(trim(shell_exec($this->getBinPath() . ' ' . escapeshellarg(json_encode($args)))));
+        $result = json_decode(trim(shell_exec($this->getBinPath() . ' ' . escapeshellarg(base64_encode(json_encode($args))))));
 
         if (!$result->success) {
             throw new Exception('Error while executing PhantomJS: "' . $result->response . '"');


### PR DESCRIPTION
To be able to pass a JSON string through the shell and retain its quotes I made PhantomJS.php base64 encode the string. converter.js now base64 decodes the string before JSON decoding it. ConverterAbstract.php now encodes the URI with three forward slashes to allow PhantomJS to load temporary files.