### PR TITLE
Fix for Warning: count(): Parameter must be an array or an object that implements Countable in H2P\Request->__construct()

### DIFF
--- a/src/H2P/Request.php
+++ b/src/H2P/Request.php
@@ -102,7 +102,7 @@ class Request
         $this->setMethod($method ?: self::METHOD_GET);
         $headers and $this->headers = $headers;
         $params and $this->params = $params;
-        if (count($cookies)) {
+        if (is_array($cookies) && count($cookies)) {
             $this->addCookies($cookies);
         }
     }


### PR DESCRIPTION
PHP7 compatibility fix: Check $cookie is an array before performing a count on it.